### PR TITLE
Fixed typo in variable name in curl error handling

### DIFF
--- a/src/LazopClient.php
+++ b/src/LazopClient.php
@@ -104,7 +104,7 @@ class LazopClient
 			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
 		}
 
-	    $output = curl_exec($ch);
+	    $response = curl_exec($ch);
 		
 		$errno = curl_errno($ch);
 
@@ -119,11 +119,11 @@ class LazopClient
 			curl_close($ch);
 			if (200 !== $httpStatusCode)
 			{
-				throw new Exception($reponse,$httpStatusCode);
+				throw new Exception($response,$httpStatusCode);
 			}
 		}
 
-		return $output;
+		return $response;
 	}
 
 	public function curl_post($url, $postFields = null, $fileFields = null,$headerFields = null)


### PR DESCRIPTION
Error:
Received an ErrorException "Undefined variable $reponse" 

Changes made:
- Assigned` curl_exec($ch)` to `$response` instead of `$output` to match the code in `curl_post` function
- Replaced the undefined variable `$reponse` with `$response;`